### PR TITLE
Bi-Directional Uart Communications

### DIFF
--- a/src/commandDataHandling/Types.h
+++ b/src/commandDataHandling/Types.h
@@ -32,6 +32,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef Types_h
 #define Types_h
 
+enum DroneState {
+   OFF = 0,
+   SETUP = 1,
+   READY = 2
+};
+
 // Keep memory small to reduce communication latencies.
 struct FlightInputs {
    int16_t throttle;

--- a/src/commandDataHandling/UartCommunications.cpp
+++ b/src/commandDataHandling/UartCommunications.cpp
@@ -52,3 +52,25 @@ void UartCommunications::write(
         sizeof(flightInputs)
     );
 }
+
+bool UartCommunications::available() {
+    return _serial->available() > sizeof(_droneState) + 1;
+}
+
+DroneState UartCommunications::read() {
+	byte* structStart = reinterpret_cast<byte*>(&_droneState);
+
+	byte data = _serial->read();
+
+	if (data == START_MARKER) {
+
+		for (byte n = 0; n < sizeof(_droneState); n++) {
+			*(structStart + n) = _serial->read();
+		}
+		while (_serial->available() > 0) {
+			byte dumpTheData = _serial->read();
+		}
+	}
+
+	return _droneState;
+}

--- a/src/commandDataHandling/UartCommunications.cpp
+++ b/src/commandDataHandling/UartCommunications.cpp
@@ -31,40 +31,44 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "UartCommunications.h"
 
-void UartCommunications::setup(
-    uint8_t rxPin,
-    uint8_t txPin,
-    unsigned long baudRate
+template <typename TxType, typename RxType>
+void UartCommunications<TxType, RxType>::setup(
+	uint8_t rxPin,
+	uint8_t txPin,
+	unsigned long baudRate
 ) {
-    _serial = new SoftwareSerial(
-        rxPin,
-        txPin
-    );
-    _serial->begin(baudRate);
+	_serial = new SoftwareSerial(
+		rxPin,
+		txPin
+	);
+	_serial->begin(baudRate);
 }
 
-void UartCommunications::write(
-    FlightInputs flightInputs
+template <typename TxType, typename RxType>
+void UartCommunications<TxType, RxType>::transmit(
+	TxType data
 ) {
-    _serial->write(START_MARKER);
-    _serial->write(
-        (char*)&flightInputs,
-        sizeof(flightInputs)
-    );
+	_serial->write(START_MARKER);
+	_serial->write(
+		(char*)&data,
+		sizeof(data)
+	);
 }
 
-bool UartCommunications::available() {
-    return _serial->available() > sizeof(_droneState) + 1;
+template <typename TxType, typename RxType>
+bool UartCommunications<TxType, RxType>::available() {
+	return _serial->available() > sizeof(_rxDataBuffer) + 1;
 }
 
-DroneState UartCommunications::read() {
-	byte* structStart = reinterpret_cast<byte*>(&_droneState);
+template <typename TxType, typename RxType>
+RxType UartCommunications<TxType, RxType>::receive() {
+	byte* structStart = reinterpret_cast<byte*>(&_rxDataBuffer);
 
 	byte data = _serial->read();
 
 	if (data == START_MARKER) {
 
-		for (byte n = 0; n < sizeof(_droneState); n++) {
+		for (byte n = 0; n < sizeof(_rxDataBuffer); n++) {
 			*(structStart + n) = _serial->read();
 		}
 		while (_serial->available() > 0) {
@@ -72,5 +76,7 @@ DroneState UartCommunications::read() {
 		}
 	}
 
-	return _droneState;
+	return _rxDataBuffer;
 }
+
+template class UartCommunications<FlightInputs, DroneState>;

--- a/src/commandDataHandling/UartCommunications.h
+++ b/src/commandDataHandling/UartCommunications.h
@@ -34,19 +34,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Types.h"
 #include "Configuration.h"
 
+template <typename TxType, typename RxType>
 class UartCommunications {
-    public:
-        void setup(
-            uint8_t rxPin,
-            uint8_t txPin,
-            unsigned long baudRate
-        );
-        void write(
-            FlightInputs flightInputs
-        );
-        bool available();
-        DroneState read();
-    private:
-        SoftwareSerial* _serial;
-        DroneState _droneState;
+	public:
+		void setup(
+			uint8_t rxPin,
+			uint8_t txPin,
+			unsigned long baudRate
+		);
+		void transmit(
+			TxType data
+		);
+		bool available();
+		RxType receive();
+	private:
+		SoftwareSerial* _serial;
+		RxType _rxDataBuffer;
 };

--- a/src/commandDataHandling/UartCommunications.h
+++ b/src/commandDataHandling/UartCommunications.h
@@ -44,6 +44,9 @@ class UartCommunications {
         void write(
             FlightInputs flightInputs
         );
+        bool available();
+        DroneState read();
     private:
         SoftwareSerial* _serial;
+        DroneState _droneState;
 };

--- a/src/commandDataHandling/commandDataHandling.ino
+++ b/src/commandDataHandling/commandDataHandling.ino
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Lights lights;
 Receiver receiver;
-UartCommunications uartCommunications;
+UartCommunications<FlightInputs, DroneState> uartCommunications;
 
 void setup() {
     lights.setup(
@@ -65,7 +65,7 @@ void loop() {
     lights.blinkingRefresh();
 
     if (receiver.available()) {
-        uartCommunications.write(
+        uartCommunications.transmit(
             receiver.read()
         );
     }

--- a/src/flightControlSystem/Types.h
+++ b/src/flightControlSystem/Types.h
@@ -32,6 +32,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef Types_h
 #define Types_h
 
+enum DroneState {
+   OFF = 0,
+   SETUP = 1,
+   READY = 2
+};
+
 // Keep memory small to reduce communication latencies.
 struct FlightInputs {
 	int16_t throttle;

--- a/src/flightControlSystem/UartCommunications.cpp
+++ b/src/flightControlSystem/UartCommunications.cpp
@@ -43,6 +43,16 @@ void UartCommunications::setup(
 	_serial->begin(baudRate);
 }
 
+void UartCommunications::write(
+	DroneState droneState
+) {
+	_serial->write(START_MARKER);
+	_serial->write(
+		(char*)&droneState,
+		sizeof(droneState)
+	);
+}
+
 bool UartCommunications::available() {
 	return _serial->available() > sizeof(_flightInputs) + 1;
 }

--- a/src/flightControlSystem/UartCommunications.h
+++ b/src/flightControlSystem/UartCommunications.h
@@ -41,6 +41,9 @@ class UartCommunications {
 			uint8_t txPin,
 			unsigned long baudRate
 		);
+		void write(
+			DroneState dronestate
+		);
 		bool available();
 		FlightInputs read();
 	private:

--- a/src/flightControlSystem/UartCommunications.h
+++ b/src/flightControlSystem/UartCommunications.h
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Configuration.h"
 #include "Types.h"
 
+template <typename TxType, typename RxType>
 class UartCommunications {
 	public:
 		void setup(
@@ -41,12 +42,12 @@ class UartCommunications {
 			uint8_t txPin,
 			unsigned long baudRate
 		);
-		void write(
-			DroneState dronestate
+		void transmit(
+			TxType data
 		);
 		bool available();
-		FlightInputs read();
+		RxType receive();
 	private:
 		SoftwareSerial* _serial;
-		FlightInputs _flightInputs;
+		RxType _rxDataBuffer;
 };

--- a/src/flightControlSystem/flightControlSystem.ino
+++ b/src/flightControlSystem/flightControlSystem.ino
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <SoftwareSerial.h>
 
-UartCommunications uartCommunications;
+UartCommunications<DroneState, FlightInputs> uartCommunications;
 Drone drone;
 FlightInputs flightInputs;
 
@@ -58,7 +58,7 @@ void setup() {
 
 void loop() {
     if (uartCommunications.available()) {
-        flightInputs = uartCommunications.read();
+        flightInputs = uartCommunications.receive();
     }
 
     drone.sendFlightInputs(


### PR DESCRIPTION
Implement the supporting architecture for syncing the drone's state between the FCS and CDH. Specifically:

* Introduced the `DroneState` enum,
* Added `transmit` functionality to the drone's `UartCommunications` class,
* Added `receive` functionality to the CDH's `UartCommunications` class, and
* Made the `UartCommunications` class generic.